### PR TITLE
Fix isZeroVal comparision for non pointer and struct fields inside a struct

### DIFF
--- a/pretty/reflect.go
+++ b/pretty/reflect.go
@@ -33,14 +33,8 @@ func isZeroVal(val reflect.Value) bool {
 		fields := typ.NumField()
 		for i := 0; i < fields; i++ {
 			sf := typ.Field(i)
-			if sf.Type.Kind() == reflect.Ptr || sf.Type.Kind() == reflect.Struct {
-				if !isZeroVal(val.Field(i)) {
-					return false
-				}
-			} else {
-				if !reflect.DeepEqual(val.Interface(), z) {
-					return false
-				}
+			if !isZeroVal(val.Field(i)) {
+				return false
 			}
 		}
 		return true

--- a/pretty/reflect.go
+++ b/pretty/reflect.go
@@ -32,7 +32,6 @@ func isZeroVal(val reflect.Value) bool {
 		typ := val.Type()
 		fields := typ.NumField()
 		for i := 0; i < fields; i++ {
-			sf := typ.Field(i)
 			if !isZeroVal(val.Field(i)) {
 				return false
 			}


### PR DESCRIPTION
Inside of a struct, for non pointer and struct fields, we were calling deepEqual on the struct val and struct zero val rather than on the field and field zero val.  Adjusted this so it recursively uses isZeroVal and simplifies the function as a whole.